### PR TITLE
Use unprefixed navigator.getUserMedia

### DIFF
--- a/imagecapture.html
+++ b/imagecapture.html
@@ -249,7 +249,7 @@ function getUserMedia() {
     }
   };
   console.log(constraints);
-  navigator.webkitGetUserMedia(constraints, gotStream,
+  navigator.getUserMedia(constraints, gotStream,
                                getUserMediaFailedCallback);
 };
 


### PR DESCRIPTION
This example could work under Firefox if the right [flag](https://github.com/w3c/mediacapture-image/blob/gh-pages/implementation-status.md#firefox) is enabled. But can't test it when it's using the prefixed getUserMedia for Chrome.